### PR TITLE
feat: handleErrorResponse

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# disable nextjs telemetry https://nextjs.org/telemetry
+NEXT_TELEMETRY_DISABLED=1
+
+# Disable logging in tests
+LOG_LEVEL=silent

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ export const config: Config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['<rootDir>/test-setup/mock-next-headers.setup.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/integration-tests/'],
 };
 

--- a/src/lib/errors/BadRequestError.ts
+++ b/src/lib/errors/BadRequestError.ts
@@ -1,0 +1,1 @@
+export default class BadRequestError extends Error {}

--- a/src/lib/errors/NotFoundError.ts
+++ b/src/lib/errors/NotFoundError.ts
@@ -1,0 +1,1 @@
+export default class NotFoundError extends Error {}

--- a/src/lib/errors/UnauthorizedError.ts
+++ b/src/lib/errors/UnauthorizedError.ts
@@ -1,0 +1,1 @@
+export default class UnauthorizedError extends Error {}

--- a/src/lib/errors/handleErrorResponse.test.ts
+++ b/src/lib/errors/handleErrorResponse.test.ts
@@ -1,0 +1,34 @@
+import BadRequestError from '@/lib/errors/BadRequestError';
+import handleErrorResponse from '@/lib/errors/handleErrorResponse';
+import NotFoundError from '@/lib/errors/NotFoundError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+
+describe('handleErrorResponse', () => {
+  it('should return 400 for bad request', async () => {
+    const response = handleErrorResponse(
+      new BadRequestError('you did the wrong thing!'),
+    );
+    expect(response.status).toEqual(400);
+    expect(await response.json()).toEqual({
+      error: 'you did the wrong thing!',
+    });
+  });
+
+  it('should return 404 for not found', async () => {
+    const response = handleErrorResponse(new NotFoundError('Item not found'));
+    expect(response.status).toEqual(404);
+    expect(await response.json()).toEqual({ error: 'Item not found' });
+  });
+
+  it('should return 401 for unauthorized', async () => {
+    const response = handleErrorResponse(new UnauthorizedError());
+    expect(response.status).toEqual(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('should return 500 for unknown', async () => {
+    const response = handleErrorResponse(new Error());
+    expect(response.status).toEqual(500);
+    expect(await response.json()).toEqual({ error: 'Unknown error' });
+  });
+});

--- a/src/lib/errors/handleErrorResponse.ts
+++ b/src/lib/errors/handleErrorResponse.ts
@@ -1,0 +1,28 @@
+import BadRequestError from '@/lib/errors/BadRequestError';
+import NotFoundError from '@/lib/errors/NotFoundError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import { getLogger } from '@/lib/logger';
+import NextResponseErrorBody from '@/types/NextResponseErrorBody';
+import { NextResponse } from 'next/server';
+
+export default function handleErrorResponse(
+  error: unknown,
+): NextResponse<NextResponseErrorBody> {
+  const logger = getLogger('handleErrorResponse');
+
+  if (error instanceof BadRequestError) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  } else if (error instanceof NotFoundError) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  } else if (error instanceof UnauthorizedError) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  } else {
+    let errorMessage;
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+    logger.error({ errorMessage }, 'Unknown error');
+
+    return NextResponse.json({ error: 'Unknown error' }, { status: 500 });
+  }
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,7 +6,7 @@ import pino, { LoggerOptions } from 'pino';
 const options: LoggerOptions = {
   base: undefined,
   // "silent" to disable logging
-  level: process.env.NODE_ENV === 'test' ? 'silent' : config.log.level,
+  level: config.log.level,
   nestedKey: 'payload',
   timestamp: pino.stdTimeFunctions.isoTime,
 };

--- a/src/types/NextResponseErrorBody.ts
+++ b/src/types/NextResponseErrorBody.ts
@@ -1,0 +1,5 @@
+type NextResponseErrorBody = {
+  error: string;
+};
+
+export default NextResponseErrorBody;

--- a/test-setup/mock-next-headers.setup.ts
+++ b/test-setup/mock-next-headers.setup.ts
@@ -1,0 +1,5 @@
+jest.mock('next/headers', () => ({
+  headers: () => ({
+    get: jest.fn(),
+  }),
+}));


### PR DESCRIPTION
## Description
- create a library to handle errors and generate a NextResponse containing the error

## Tests
- add unit test
- use the `.env.test` file to disable logging in tests
- since we're logging in a unit test, we must mock the next headers. Do this globally to avoid needing to do it in other tests.
