### PR TITLE
feat: login page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "pino": "9.5.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-hook-form": "7.53.2",
         "tailwind-merge": "2.5.4",
         "tailwindcss-animate": "1.0.7",
         "tozod": "3.0.0",
@@ -15119,6 +15120,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
+      "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pino": "9.5.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-hook-form": "7.53.2",
     "tailwind-merge": "2.5.4",
     "tailwindcss-animate": "1.0.7",
     "tozod": "3.0.0",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { AuthPostRequestBody } from '@/app/api/auth/route';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { postAuth } from '@/lib/api';
+import useAppContext from 'hooks/useAppContext';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+export default function LoginPage() {
+  const { setAuth } = useAppContext();
+  const router = useRouter();
+
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    reset,
+  } = useForm<AuthPostRequestBody>();
+
+  const onSubmit: SubmitHandler<AuthPostRequestBody> = useCallback(
+    async (formInput) => {
+      try {
+        const { email, password } = formInput;
+
+        const auth = await postAuth({ email, password });
+
+        setAuth(auth);
+
+        // TODO navigate back to where they were if this was a redirect
+        router.push('/');
+      } catch {
+        // TODO handle error
+      } finally {
+        reset();
+      }
+    },
+    [reset, router, setAuth],
+  );
+
+  return (
+    <div className="flex justify-center">
+      <div className="grid gap-4 w-fit">
+        <div className="space-y-2">
+          <h1>Login</h1>
+        </div>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="grid gap-5">
+            <div className="grid gap-2">
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  className="col-span-3 h-8"
+                  variant={errors['email'] ? 'error' : 'default'}
+                  {...register('email', { required: true })}
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="password">Password</Label>
+                <Input
+                  id="password"
+                  className="col-span-3 h-8"
+                  type="password"
+                  variant={errors['password'] ? 'error' : 'default'}
+                  {...register('password', { required: true })}
+                />
+              </div>
+            </div>
+            <div className="flex justify-end">
+              <Button variant="default" type="submit">
+                Submit
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body className="flex h-screen w-screen items-center justify-center">
         <AppContextProvider>{children}</AppContextProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,34 @@
 'use client';
 
+import { Button } from '@/components/ui/button';
 import useAppContext from '@/hooks/useAppContext';
+import Link from 'next/link';
+
+function NavLink({
+  children,
+  path,
+}: {
+  children: React.ReactNode;
+  path: string;
+}) {
+  const buttonContent = (
+    <Button
+      variant="outline"
+      className="flex flex-col items-center py-0 h-[80px] w-[150px] text-lg"
+    >
+      {children}
+    </Button>
+  );
+
+  return <Link href={path}>{buttonContent}</Link>;
+}
 
 export default function Home() {
   const { auth } = useAppContext();
 
   return (
     <div>
-      <main className="flex h-screen w-screen items-center justify-center">
+      <main>
         <div className="flex flex-col gap-4 items-center">
           <h1>Home</h1>
           {auth.isLoggedIn ? (
@@ -15,6 +36,13 @@ export default function Home() {
           ) : (
             <div>User is logged out</div>
           )}
+          <div className="flex gap-4">
+            <NavLink path="/login">
+              <p className="whitespace-normal break-normal">
+                Login Page (unprotected)
+              </p>
+            </NavLink>
+          </div>
         </div>
       </main>
     </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { AuthPostRequestBody } from '@/app/api/auth/route';
 import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import Auth from '@/types/Auth';
 
@@ -32,4 +33,17 @@ export async function _api<T>(
 
 export async function getAuth(): Promise<Auth> {
   return _api<Auth>('/api/auth');
+}
+
+export async function postAuth({
+  email,
+  password,
+}: AuthPostRequestBody): Promise<Auth> {
+  return _api<Auth>('/api/auth', {
+    body: JSON.stringify({ email, password }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
 }


### PR DESCRIPTION
## Description
- add a login page which calls the /api/auth POST route to login the user
- store this login page within the "auth" route group. This is to signify that it is used for authentication and not protected / require login to view.
- add a simple link to the login page on the home page for demo

## Tests
manual demo:


https://github.com/user-attachments/assets/a41e4114-0be4-40b6-bed0-d057f793343c

