### PR TITLE
feat: client error hooks

### DIFF
--- a/jest.all.config.ts
+++ b/jest.all.config.ts
@@ -14,6 +14,7 @@ const extendedConfig: Config = {
     'src/components/*',
     'src/config/*',
     'src/middleware.ts',
+    'src/lib/api.ts',
     'src/lib/logger.ts',
     'src/lib/prisma.ts',
     'src/types/*',

--- a/src/app/error/page.tsx
+++ b/src/app/error/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+
+export default function ErrorPage() {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col gap-4 items-center justify-center">
+      <h2>Something went wrong!</h2>
+      <Button onClick={() => router.push('/')}>Try again</Button>
+    </div>
+  );
+}

--- a/src/hooks/useHandleError.test.ts
+++ b/src/hooks/useHandleError.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import useHandleError from '@/hooks/useHandleError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import { renderHook } from '@testing-library/react';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe('useHandleError', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('route to the login page on UnauthorizedError', () => {
+    const {
+      result: {
+        current: { handleError },
+      },
+    } = renderHook(() => useHandleError());
+
+    handleError(new UnauthorizedError());
+
+    expect(mockPush).toHaveBeenCalledWith('/login?login-error=unauthorized');
+  });
+
+  it('route to error page on Error', () => {
+    const {
+      result: {
+        current: { handleError },
+      },
+    } = renderHook(() => useHandleError());
+
+    handleError(new Error());
+
+    expect(mockPush).toHaveBeenCalledWith('/error');
+  });
+});

--- a/src/hooks/useHandleError.ts
+++ b/src/hooks/useHandleError.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import useLoginError from '@/hooks/useLoginError';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import LoginError from '@/types/LoginError';
+import { useRouter } from 'next/navigation';
+import { useCallback } from 'react';
+
+export type UseHandleErrorResult = {
+  handleError: (error: unknown) => void;
+};
+
+export default function useHandleError(): UseHandleErrorResult {
+  const router = useRouter();
+  const { buildLoginErrorUrl } = useLoginError();
+
+  const handleError = useCallback(
+    (error: unknown) => {
+      if (error instanceof UnauthorizedError) {
+        return router.push(buildLoginErrorUrl(LoginError.UNAUTHORIZED));
+      } else {
+        return router.push('/error');
+      }
+    },
+    [buildLoginErrorUrl, router],
+  );
+
+  return { handleError };
+}

--- a/src/hooks/useLoginError.test.ts
+++ b/src/hooks/useLoginError.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import useLoginError, { UseLoginErrorResult } from '@/hooks/useLoginError';
+import LoginError from '@/types/LoginError';
+import { renderHook } from '@testing-library/react';
+
+describe('useLoginError', () => {
+  describe('buildLoginErrorUrl', () => {
+    let buildLoginErrorUrl: UseLoginErrorResult['buildLoginErrorUrl'];
+
+    beforeEach(() => {
+      ({
+        result: {
+          current: { buildLoginErrorUrl },
+        },
+      } = renderHook(() => useLoginError()));
+    });
+
+    it('should build the correct invalid login url', () => {
+      expect(buildLoginErrorUrl(LoginError.INVALID_LOGIN)).toEqual(
+        '/login?login-error=invalid-login',
+      );
+    });
+
+    it('should build the correct unauthorized url', () => {
+      expect(buildLoginErrorUrl(LoginError.UNAUTHORIZED)).toEqual(
+        '/login?login-error=unauthorized',
+      );
+    });
+  });
+
+  describe('parseLoginErrorUrl', () => {
+    let parseLoginErrorUrl: UseLoginErrorResult['parseLoginErrorUrl'];
+
+    beforeEach(() => {
+      ({
+        result: {
+          current: { parseLoginErrorUrl },
+        },
+      } = renderHook(() => useLoginError()));
+    });
+
+    it('should parse invalid login', () => {
+      const searchParams = new URLSearchParams('login-error=invalid-login');
+      expect(parseLoginErrorUrl(searchParams)).toEqual({
+        errorMessage: 'Invalid email and/or password',
+      });
+    });
+
+    it('should parse unauthorized', () => {
+      const searchParams = new URLSearchParams('login-error=unauthorized');
+      expect(parseLoginErrorUrl(searchParams)).toEqual({
+        errorMessage: 'Please login to continue',
+      });
+    });
+
+    it('should return no error message when login-error is not recognized', () => {
+      const searchParams = new URLSearchParams('login-error=foo');
+      expect(parseLoginErrorUrl(searchParams)).toEqual({
+        errorMessage: undefined,
+      });
+    });
+  });
+});

--- a/src/hooks/useLoginError.ts
+++ b/src/hooks/useLoginError.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import LoginError from '@/types/LoginError';
+import { useCallback } from 'react';
+
+export type UseLoginErrorResult = {
+  buildLoginErrorUrl: (loginError: LoginError) => string;
+  parseLoginErrorUrl: (searchParams: URLSearchParams) => {
+    errorMessage?: string;
+  };
+};
+
+const KEY = 'login-error';
+const VALUES = {
+  [LoginError.INVALID_LOGIN]: 'invalid-login',
+  [LoginError.UNAUTHORIZED]: 'unauthorized',
+} as const;
+
+export default function useLoginError(): UseLoginErrorResult {
+  const buildLoginErrorUrl = useCallback((loginError: LoginError) => {
+    return `/login?${KEY}=${VALUES[loginError]}`;
+  }, []);
+
+  const parseLoginErrorUrl = useCallback((searchParams: URLSearchParams) => {
+    const loginError = searchParams.get(KEY);
+
+    let errorMessage;
+    if (loginError === VALUES[LoginError.INVALID_LOGIN]) {
+      errorMessage = 'Invalid email and/or password';
+    } else if (loginError === VALUES[LoginError.UNAUTHORIZED]) {
+      errorMessage = 'Please login to continue';
+    }
+
+    return { errorMessage };
+  }, []);
+
+  return { buildLoginErrorUrl, parseLoginErrorUrl };
+}

--- a/src/types/LoginError.ts
+++ b/src/types/LoginError.ts
@@ -1,0 +1,6 @@
+enum LoginError {
+  INVALID_LOGIN,
+  UNAUTHORIZED,
+}
+
+export default LoginError;


### PR DESCRIPTION
## Description
- add hook to handle errors on the client side
- if the error is UnauthorizedError, use the useLoginError to build a redirect
- useLoginError will then be used to parse the login error message to display
- build an error page to show when things go wrong

## Tests
- add unit tests

screenshot of error page:
![error](https://github.com/user-attachments/assets/8c029f38-83ab-4110-8494-100b57e2e618)
