### PR TITLE
feat: auth middleware

### DIFF
--- a/jest.all.config.ts
+++ b/jest.all.config.ts
@@ -15,6 +15,7 @@ const extendedConfig: Config = {
     'src/config/*',
     'src/middleware.ts',
     'src/lib/api.ts',
+    'src/lib/fakes/*',
     'src/lib/logger.ts',
     'src/lib/prisma.ts',
     'src/types/*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "3.2.2",
+        "@faker-js/faker": "9.2.0",
         "@storybook/addon-essentials": "8.4.5",
         "@storybook/addon-interactions": "8.4.5",
         "@storybook/blocks": "8.4.5",
@@ -2707,6 +2708,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.2.0.tgz",
+      "integrity": "sha512-ulqQu4KMr1/sTFIYvqSdegHT8NIkt66tFAkugGnHA+1WAfEn6hMzNR+svjXGFRVLnapxvej67Z/LwchFrnLBUg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "3.2.2",
+    "@faker-js/faker": "9.2.0",
     "@storybook/addon-essentials": "8.4.5",
     "@storybook/addon-interactions": "8.4.5",
     "@storybook/blocks": "8.4.5",

--- a/src/lib/auth-middleware.test.ts
+++ b/src/lib/auth-middleware.test.ts
@@ -1,0 +1,54 @@
+import config from '@/config/index';
+import authMiddleware from '@/lib/auth-middleware';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import { fakePrismaUser } from '@/lib/fakes/user.fake';
+import prisma from '@/lib/prisma';
+import { NextRequest } from 'next/server';
+
+const url = 'http://localhost';
+const authCookieName = config.auth.cookieName;
+
+const mockFind = jest.spyOn(prisma.user, 'findFirst');
+
+describe('src/lib/auth-middleware', () => {
+  beforeEach(() => {
+    mockFind.mockReset();
+  });
+
+  const user1 = fakePrismaUser();
+
+  it('should return the user with a valid cookie', async () => {
+    const request = new NextRequest(url);
+    request.cookies.set(authCookieName, user1.userId);
+    mockFind.mockResolvedValue(user1);
+
+    expect(await authMiddleware(request)).toEqual({
+      user: user1,
+    });
+  });
+
+  it('should fail when the cookie does not exist', async () => {
+    const request = new NextRequest(url);
+    mockFind.mockResolvedValue(user1);
+
+    expect.assertions(1);
+    try {
+      await authMiddleware(request);
+    } catch (err) {
+      expect(err instanceof UnauthorizedError).toBeTruthy();
+    }
+  });
+
+  it('should fail when the user does not match/exist', async () => {
+    const request = new NextRequest(url);
+    request.cookies.set(authCookieName, 'foo');
+    mockFind.mockResolvedValue(null);
+
+    expect.assertions(1);
+    try {
+      await authMiddleware(request);
+    } catch (err) {
+      expect(err instanceof UnauthorizedError).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/auth-middleware.ts
+++ b/src/lib/auth-middleware.ts
@@ -1,0 +1,32 @@
+import projectConfig from '@/config/index';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import { getLogger } from '@/lib/logger';
+import prisma from '@/lib/prisma';
+import Session from '@/types/Session';
+import { NextRequest } from 'next/server';
+
+const authCookieName = projectConfig.auth.cookieName;
+
+export default async function authMiddleware(
+  request: NextRequest,
+): Promise<Session> {
+  const logger = getLogger('authMiddleware');
+
+  const cookie = request.cookies.get(authCookieName);
+  logger.trace({ cookie }, 'authMiddleware cookie');
+  const userId = cookie?.value;
+  if (!userId) {
+    throw new UnauthorizedError();
+  }
+
+  const user = await prisma.user.findFirst({
+    where: { userId },
+  });
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+
+  return {
+    user,
+  };
+}

--- a/src/lib/fakes/user.fake.ts
+++ b/src/lib/fakes/user.fake.ts
@@ -1,0 +1,20 @@
+import User from '@/types/User';
+import { faker } from '@faker-js/faker';
+import { User as PrismaUser } from '@prisma/client';
+
+export function fakeUser(): User {
+  return {
+    createdAt: faker.date.past(),
+    email: faker.internet.email(),
+    updatedAt: faker.date.past(),
+    userId: faker.string.uuid(),
+  };
+}
+
+// omit passwordHash to match our default implementation
+export function fakePrismaUser(): Omit<PrismaUser, 'passwordHash'> {
+  return {
+    ...fakeUser(),
+    id: faker.number.int(),
+  };
+}

--- a/src/types/Session.ts
+++ b/src/types/Session.ts
@@ -1,0 +1,7 @@
+import User from '@/types/User';
+
+type Session = {
+  user: User;
+};
+
+export default Session;


### PR DESCRIPTION
## Description
Next.js middleware as of now requires it to be run on the Edge runtime. This runtime has limitations, including not being able to access crypto libraries needed for `bcrypt`, nor being able to run database operations (prisma). This kinda leaves us without a lot of options, if we want our middleware to perform auth checks. Of these sub-optimal options, the best of which, IMO, is to run "middleware" directly from the routes themselves rather than implicitly using Next.js.

So create our own auth middleware library which will be used within our protected routes. This middleware confirms the auth cookie exists and is populated with a user's `userId`. It returns a `Session` which contains only the `User`, or throws `UnauthorizedError` if the auth check fails.

## Tests

- add unit test for our new middleware library
- add "fakes" to generate a fake User used in the test

## Documentation

- RFC: Switchable Next.js Runtime https://github.com/vercel/next.js/discussions/34179
- Switchable Runtime for Middleware (Allow Node.js APIs in Middleware) https://github.com/vercel/next.js/discussions/46722

Demo of expected use:

```typescript
// /api/protected/widgets/route.ts

export async function GET(request: NextRequest) {
  try {
    // verify the user auth, and load the user session
    const session = await authMiddleware(request);

    // use the user data to load the widgets
    const widgets = await prisma.widget.findMany({
      where: { userId: session.user.userId },
    });

    return NextResponse.json({ data: widgets });
  } catch (error: unknown) {
    // handle errors, including UnauthorizedError by returning 401
    return handleErrorResponse(error);
  }
}
```
