### PR TITLE
feat: Widget add description

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Reset the database, re-run migrations, and re-seed the database:
 npm run db:reset
 ```
 
+#### Seed Configuration
+
+The following environment variables are available to set specifics:
+
+Number of Widgets to create (defaults to 10):
+
+```
+SEED_NUM_WIDGETS=10
+```
+
 ## Tests
 
 ### Lint and Type Checking

--- a/integration-tests/fixtures/user.fixture.ts
+++ b/integration-tests/fixtures/user.fixture.ts
@@ -12,9 +12,9 @@ const userFixtures: Prisma.UserCreateInput[] = [
     widgets: {
       createMany: {
         data: [
-          { name: 'Widget 1' },
-          { name: 'Widget 2' },
-          { name: 'Widget 3' },
+          { description: 'Description 1', name: 'Widget 1' },
+          { description: 'Description 2', name: 'Widget 2' },
+          { description: 'Description 3', name: 'Widget 3' },
         ],
       },
     },

--- a/integration-tests/tests/widgets/get-widgets.test.ts
+++ b/integration-tests/tests/widgets/get-widgets.test.ts
@@ -23,6 +23,7 @@ describe('/api/protected/widgets GET Integration Test', () => {
       widgets = await prisma.widget.findMany({
         select: {
           createdAt: true,
+          description: true,
           name: true,
           updatedAt: true,
           widgetId: true,

--- a/prisma/migrations/20241203192353_add_description_to_widgets/migration.sql
+++ b/prisma/migrations/20241203192353_add_description_to_widgets/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Widget" ADD COLUMN     "description" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,8 +28,9 @@ model Widget {
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @db.Timestamptz(3)
 
-  widgetId String @unique @default(nanoid(20))
-  name     String
+  widgetId    String @unique @default(nanoid(20))
+  name        String
+  description String
 
   userId String
   user   User   @relation(fields: [userId], references: [userId], onDelete: Cascade)

--- a/prisma/seeds/seeds.ts
+++ b/prisma/seeds/seeds.ts
@@ -1,7 +1,29 @@
+import _ from 'lodash';
 import { generateUsers } from './users/users.seeds';
 import { generateWidgets } from './widgets/widgets.seeds';
 
+function getNumberEnvVariable(
+  envValue: string | undefined,
+  envVariableName: string,
+  defaultValue?: number,
+): number {
+  if (envValue) {
+    // allow the string number to include underscores
+    return _.toNumber(envValue.replace(/_/g, ''));
+  } else if (defaultValue) {
+    return defaultValue;
+  } else {
+    throw new Error(`Environment variable ${envVariableName} required`);
+  }
+}
+
 export default async function generateSeeds() {
   await generateUsers();
-  await generateWidgets();
+
+  const numWidgets = getNumberEnvVariable(
+    process.env.SEED_NUM_WIDGETS,
+    'SEED_NUM_WIDGETS',
+    10,
+  );
+  await generateWidgets(numWidgets);
 }

--- a/prisma/seeds/widgets/widgets.seeds.ts
+++ b/prisma/seeds/widgets/widgets.seeds.ts
@@ -1,16 +1,19 @@
 import prisma from '@/lib/prisma';
+import { faker } from '@faker-js/faker';
+import { Prisma } from '@prisma/client';
+import _ from 'lodash';
 
-export async function generateWidgets() {
+export async function generateWidgets(numWidgets: number) {
   const { userId } = await prisma.user.findFirstOrThrow({
     select: { userId: true },
     where: { email: 'test@fake.com' },
   });
 
-  await prisma.widget.createMany({
-    data: [
-      { name: 'Widget 1', userId },
-      { name: 'Widget 2', userId },
-      { name: 'Widget 3', userId },
-    ],
-  });
+  const data: Prisma.WidgetCreateManyInput[] = _.times(numWidgets, (i) => ({
+    description: faker.lorem.sentence(),
+    name: `Widget ${i + 1}`,
+    userId,
+  }));
+
+  await prisma.widget.createMany({ data });
 }

--- a/src/app/api/protected/widgets/route.ts
+++ b/src/app/api/protected/widgets/route.ts
@@ -18,6 +18,7 @@ export async function GET(
     const widgets = await prisma.widget.findMany({
       select: {
         createdAt: true,
+        description: true,
         name: true,
         updatedAt: true,
         widgetId: true,


### PR DESCRIPTION
## Description
- to make the `Widget` object a bit more interesting to view, add a description attribute to the database table.
- update the internal type, API, seeds, and integration tests
- expose the number of widgets created in seeds via an environment variable

## Tests
- existing lint and tests cover refactor
- manually verified environment variable allows for more Widget creation