### PR TITLE
feat: Widgets page (protected)

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import useAppContext from '@/hooks/useAppContext';
+import useLoginError from '@/hooks/useLoginError';
+import LoginError from '@/types/LoginError';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function ProtectedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const {
+    auth: { isLoggedIn },
+  } = useAppContext();
+  const router = useRouter();
+  const { buildLoginErrorUrl } = useLoginError();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.push(buildLoginErrorUrl(LoginError.UNAUTHORIZED));
+    }
+  }, [isLoggedIn, router, buildLoginErrorUrl]);
+
+  if (!isLoggedIn) {
+    return <></>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(protected)/widgets/page.tsx
+++ b/src/app/(protected)/widgets/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import WidgetsTable from '@/components/widget/WidgetsTable';
+import useHandleError from '@/hooks/useHandleError';
+import useLoginError from '@/hooks/useLoginError';
+import { getWidgets } from '@/lib/api';
+import UnauthorizedError from '@/lib/errors/UnauthorizedError';
+import LoginError from '@/types/LoginError';
+import Widget from '@/types/Widget';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+export default function WidgetsPage() {
+  const [widgets, setWidgets] = useState<Widget[]>([]);
+  const [isLoadingWidgets, setIsLoadingWidgets] = useState(true);
+  const { handleError } = useHandleError();
+  const router = useRouter();
+  const { buildLoginErrorUrl } = useLoginError();
+
+  const loadWidgets = useCallback(async () => {
+    setIsLoadingWidgets(true);
+    try {
+      const data = await getWidgets();
+      setWidgets(data);
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        return router.push(buildLoginErrorUrl(LoginError.UNAUTHORIZED));
+      }
+
+      return handleError(error);
+    } finally {
+      setIsLoadingWidgets(false);
+    }
+  }, [buildLoginErrorUrl, handleError, router]);
+
+  useEffect(() => {
+    loadWidgets();
+  }, [loadWidgets]);
+
+  return (
+    <div>
+      <div className="flex flex-col gap-5">
+        <h1>Widgets</h1>
+
+        <div className="rounded-md border">
+          <WidgetsTable
+            widgets={widgets}
+            linkPathname="/widgets"
+            isLoading={isLoadingWidgets}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/protected/widgets/route.ts
+++ b/src/app/api/protected/widgets/route.ts
@@ -16,6 +16,9 @@ export async function GET(
     const session = await authMiddleware(request);
 
     const widgets = await prisma.widget.findMany({
+      orderBy: {
+        id: 'asc',
+      },
       select: {
         createdAt: true,
         description: true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="flex h-screen w-screen items-center justify-center">
-        <AppContextProvider>{children}</AppContextProvider>
+        <AppContextProvider>
+          <main className="flex flex-col flex-1 md:items-center mb-12">
+            <div className="w-full h-full px-4 md:w-[768px] md:px-0">
+              {children}
+            </div>
+          </main>
+        </AppContextProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,11 @@ export default function Home() {
                 Login Page (unprotected)
               </p>
             </NavLink>
+            <NavLink path="/widgets">
+              <p className="whitespace-normal break-normal">
+                Widgets Page (protected)
+              </p>
+            </NavLink>
           </div>
         </div>
       </main>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { AuthPostRequestBody } from '@/app/api/auth/route';
 import UnauthorizedError from '@/lib/errors/UnauthorizedError';
 import Auth from '@/types/Auth';
+import Widget from '@/types/Widget';
 
 /**
  * Wrapper around fetch, expecting and returning a JSON typed response
@@ -46,4 +47,12 @@ export async function postAuth({
     },
     method: 'POST',
   });
+}
+
+// *************************************************************
+// ************************ WIDGETS ***************************
+// *************************************************************
+
+export async function getWidgets(): Promise<Widget[]> {
+  return _api<Widget[]>('/api/protected/widgets');
 }


### PR DESCRIPTION
## Description
- add a "protected" page which displays the widgets in a table
- this page lives under the (protected) route group, which checks to see if the user is logged in before proceeding. This will force a redirect in the case the user is not logged in.
- in the case the user gets to the protected page but has an invalid auth, the API will respond with Unauthorized. So wrap our `getWidgets` API call in a try/catch to redirect if Unauthorized.

## Tests
Manual demo showing:
1. logged out user attempting to navigate to the protected page
2. logged in user successfully viewing the protected page and Widgets table
3. user with bad auth (deleted the cookie, but client still thinks logged in), browsing to protected page but API call fails and causes redirect


https://github.com/user-attachments/assets/23d178c3-d77e-4550-a277-691a4be135f4

