### PR TITLE
feat: Login return redirect

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -34,8 +34,9 @@ function Error() {
 export default function LoginPage() {
   const { setAuth } = useAppContext();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { handleError } = useHandleError();
-  const { buildLoginErrorUrl } = useLoginError();
+  const { parseReturnUrl, updateLoginError } = useLoginError();
 
   const {
     formState: { errors },
@@ -53,12 +54,14 @@ export default function LoginPage() {
 
         setAuth(auth);
 
-        // TODO navigate back to where they were if this was a redirect
-        router.push('/');
+        const { returnUrl } = parseReturnUrl(searchParams);
+        router.push(returnUrl || '/');
       } catch (error) {
         // handle this case specifically since we know they entered invalid credentials
         if (error instanceof UnauthorizedError) {
-          return router.push(buildLoginErrorUrl(LoginError.INVALID_LOGIN));
+          return router.push(
+            updateLoginError(LoginError.INVALID_LOGIN, searchParams),
+          );
         }
 
         return handleError(error);
@@ -66,7 +69,15 @@ export default function LoginPage() {
         reset();
       }
     },
-    [buildLoginErrorUrl, handleError, reset, router, setAuth],
+    [
+      handleError,
+      parseReturnUrl,
+      reset,
+      router,
+      searchParams,
+      setAuth,
+      updateLoginError,
+    ],
   );
 
   return (

--- a/src/hooks/useHandleError.test.ts
+++ b/src/hooks/useHandleError.test.ts
@@ -8,6 +8,7 @@ import { renderHook } from '@testing-library/react';
 
 const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
+  usePathname: () => '/path',
   useRouter: () => ({ push: mockPush }),
 }));
 
@@ -25,7 +26,9 @@ describe('useHandleError', () => {
 
     handleError(new UnauthorizedError());
 
-    expect(mockPush).toHaveBeenCalledWith('/login?login-error=unauthorized');
+    expect(mockPush).toHaveBeenCalledWith(
+      '/login?login-error=unauthorized&return-url=/path',
+    );
   });
 
   it('route to error page on Error', () => {

--- a/src/hooks/useLoginError.ts
+++ b/src/hooks/useLoginError.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import LoginError from '@/types/LoginError';
+import { usePathname } from 'next/navigation';
 import { useCallback } from 'react';
 
 export type UseLoginErrorResult = {
@@ -8,31 +9,69 @@ export type UseLoginErrorResult = {
   parseLoginErrorUrl: (searchParams: URLSearchParams) => {
     errorMessage?: string;
   };
+  parseReturnUrl: (searchParams: URLSearchParams) => {
+    returnUrl: string | null;
+  };
+  updateLoginError: (
+    loginError: LoginError,
+    searchParams: URLSearchParams,
+  ) => string;
 };
 
-const KEY = 'login-error';
-const VALUES = {
+const LOGIN_ERROR_KEY = 'login-error';
+const LOGIN_ERROR_VALUES = {
   [LoginError.INVALID_LOGIN]: 'invalid-login',
   [LoginError.UNAUTHORIZED]: 'unauthorized',
 } as const;
+const RETURN_URL_KEY = 'return-url';
 
 export default function useLoginError(): UseLoginErrorResult {
-  const buildLoginErrorUrl = useCallback((loginError: LoginError) => {
-    return `/login?${KEY}=${VALUES[loginError]}`;
-  }, []);
+  const pathname = usePathname();
+
+  const buildLoginErrorUrl = useCallback(
+    (loginError: LoginError) => {
+      return `/login?${LOGIN_ERROR_KEY}=${LOGIN_ERROR_VALUES[loginError]}&${RETURN_URL_KEY}=${pathname}`;
+    },
+    [pathname],
+  );
 
   const parseLoginErrorUrl = useCallback((searchParams: URLSearchParams) => {
-    const loginError = searchParams.get(KEY);
+    const loginError = searchParams.get(LOGIN_ERROR_KEY);
 
     let errorMessage;
-    if (loginError === VALUES[LoginError.INVALID_LOGIN]) {
+    if (loginError === LOGIN_ERROR_VALUES[LoginError.INVALID_LOGIN]) {
       errorMessage = 'Invalid email and/or password';
-    } else if (loginError === VALUES[LoginError.UNAUTHORIZED]) {
+    } else if (loginError === LOGIN_ERROR_VALUES[LoginError.UNAUTHORIZED]) {
       errorMessage = 'Please login to continue';
     }
 
     return { errorMessage };
   }, []);
 
-  return { buildLoginErrorUrl, parseLoginErrorUrl };
+  const parseReturnUrl = useCallback((searchParams: URLSearchParams) => {
+    const returnUrl = searchParams.get(RETURN_URL_KEY);
+
+    return { returnUrl };
+  }, []);
+
+  const updateLoginError = useCallback(
+    (loginError: LoginError, searchParams: URLSearchParams) => {
+      let returnUrl = `/login?${LOGIN_ERROR_KEY}=${LOGIN_ERROR_VALUES[loginError]}`;
+
+      const existingReturnUrl = searchParams.get(RETURN_URL_KEY);
+      if (existingReturnUrl) {
+        returnUrl += `&${RETURN_URL_KEY}=${existingReturnUrl}`;
+      }
+
+      return returnUrl;
+    },
+    [],
+  );
+
+  return {
+    buildLoginErrorUrl,
+    parseLoginErrorUrl,
+    parseReturnUrl,
+    updateLoginError,
+  };
 }


### PR DESCRIPTION
## Description
- Add logic to the `useLoginError` hook to include the return URL which we should navigate to once we have successfully authenticated
- Use this in the login page
- Also provide an option to update the error message without updating the return URL, which is necessary in the failed login path of the login page. In this case, we only want to update the message, but continue to return them to where they came from.

## Tests
- add and update unit tests

demo of login:

https://github.com/user-attachments/assets/756902f2-e3c6-4b2a-a32f-085b561767b5

